### PR TITLE
About

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -23,7 +23,7 @@
                 </ul>
 
                 <p>Developers Only</p>
-                <p>Developers and aspiring developers only, please!  There are some fantastic groups for women tech entrepreneurs/social media marketers out there, which some of us participate in as well, but let's keep this group primarily focused on Python programming.</p>
+                <p>Developers and aspiring developers only, please!  There are some fantastic groups for women in other areas of technology, which some of us participate in as well, but let's keep this group primarily focused on Python programming.</p>
             </aside>
 
         </article>


### PR DESCRIPTION
Suggesting "developers only" is more general to not call out women working in social media. 
