### PR TITLE
Add button to tweet blog posts

### DIFF
--- a/www/_templates/post.html
+++ b/www/_templates/post.html
@@ -17,6 +17,11 @@
             {% endif %}
             <h3>{{ post.date }}{% if post.tags %} | Tag: <span>&raquo;</span> {% for tag in post.tags %}<a href="{{ get_url(tags[tag].url) }}">{{ tag }}</a>{% if not loop.last %}, {% endif %}{% endfor %}{% endif %}</h3>
 
+            <div>
+                <a href="https://twitter.com/share" class="twitter-share-button" data-hashtags="pyladies">Tweet</a>
+                <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
+            </div>
+
             {{ post.content }}
         </article>
     </section>


### PR DESCRIPTION
This PR is meant to address this issue: https://github.com/pyladies/pyladies/issues/80
Actually it's not a Twitter button specifically for the _current_ (I guess, latest) blog post...
Any and every blog post can now be tweeted by clicking the button.  I didn't consider time, or a feed thing...  Not too sure :p @econchick
