### PR TITLE
Modify site template to fix issue #169 for meetup display

### DIFF
--- a/www/_templates/site.html
+++ b/www/_templates/site.html
@@ -17,7 +17,12 @@
     <script type="text/javascript" src="{{ get_asset('js/meetup_widget.js') }}"></script>
     <script type="text/javascript">
         $(document).ready(function() {
-            var meetupIds = '{% for chapter in site.chapters %}{{ chapter.meetup_id }}{% if not loop.last %},{% endif %}{% endfor %}';
+            var meetupIds = "{% for chapter in site.chapters -%}
+                               {%- if chapter.meetup_id -%}
+                                  {{ chapter.meetup_id }}
+                                  {%- if not loop.last -%},{% endif %}
+                               {%- endif %}
+                            {%- endfor -%}";
             PyladiesMeetupWidget.addUpcomingMeetups(meetupIds);
         });
 	</script>


### PR DESCRIPTION
Fixes the meetup display on home page.

Add an additional check to see if the meetup_id exists for a site. If so, add the meetup to the list of meetup_ids.