### PR TITLE
Move text on remote site into center content area

### DIFF
--- a/remote/www/events/index.html
+++ b/remote/www/events/index.html
@@ -1,6 +1,6 @@
 {% extends "layout.html" %}
 {% block content %}
-<div class="indented-text">
+<div class="container">
 <div id="content"
 <div id="upcomingMeetupsList"></div>
 <dl>

--- a/remote/www/index.html
+++ b/remote/www/index.html
@@ -46,6 +46,7 @@
 
 
 
+      <div class="container">
       <div id="organizers" class="row">
         <div class="col-lg-4 title">
           <h2>PyLadies Remote Organizer</h2>
@@ -72,4 +73,5 @@
         <p class="pull-right"><a href="#">Back to top</a></p>
         <p>&copy; 2015 PyLadies Remote</p>
       </footer>
+      </div>
 {% endblock %}

--- a/remote/www/resources/index.html
+++ b/remote/www/resources/index.html
@@ -1,6 +1,6 @@
 {% extends "layout.html" %}
 {% block content %}
-<div class="indented-text">
+<div class="container">
     <h1>Resources</h1>
     <ul id="resource-types">
     	<li><h3>Python</h3></li>


### PR DESCRIPTION
@ossanna16 asked if I could open a pull request fixing #188.  I tried this out using Jekyll locally and it looks like the screenshots I posted in #188.