### PR TITLE
adding pune site link for locations page

### DIFF
--- a/www/config.yml
+++ b/www/config.yml
@@ -233,7 +233,8 @@ chapters:
       meetup: pyladies-rdu
 
     - name:      Pune, India
-      website: pune
+      website: http://pune.pyladies.com/
+      external_website: true
       image: pyladies_pune.jpeg
       email: pune@pyladies.com
       twitter: PyladiesPune


### PR DESCRIPTION
Hey Lynn!

Now that the PyLadies Pune site is live, I have updated the website link to http://pune.pyladies.com/ in the config.yml file.

Regards,
Shrreya