### PR TITLE
Update How to IRC resource

### DIFF
--- a/www/_posts/2013/2013-05-07-irc-resources.md
+++ b/www/_posts/2013/2013-05-07-irc-resources.md
@@ -5,7 +5,8 @@ tags: ["how-to", "irc"]
 category: [resources, pyladies]
 
 ---
-Updated August 24, 2015
+
+Updated March 7, 2019
 
 [IRC](http://en.wikipedia.org/wiki/Internet_Relay_Chat) is a great way to get
 in touch with open source developers around the world. The FreeNode network
@@ -17,20 +18,16 @@ a guide for getting started with IRC and joining the discussion on the #pyladies
 channel. Let's start by using a web based IRC chat client, setting up an IRC
 nickname, and joining the friendly #pyladies channel.
 
-
 ## Connect to IRC using a web client
 
 Let's start by using a web based IRC client:
 
-  * Go to https://webchat.freenode.net/?channels=pyladies
-  * For an IRC "Nickname", pick an available username (legal characters are
-    anything <code>A-Z</code>, <code>0-9</code>, <code>-</code> and <code>_</code>)
-  * Fill out the captcha code
-  * Do not fill in any other fields (other than nickname and captcha) and hit
-    the "Connect" button
-
-![Webchat window](https://dl.dropboxusercontent.com/u/39730/freenode0.PNG)
-
+- Go to https://webchat.freenode.net/?channels=pyladies
+- For an IRC "Nickname", pick an available username (legal characters are
+  anything <code>A-Z</code>, <code>0-9</code>, <code>-</code> and <code>_</code>)
+- Fill out the captcha code
+- Do not fill in any other fields (other than nickname and captcha) and hit
+  the "Connect" button
 
 ## Register your Nickname
 
@@ -38,22 +35,19 @@ Once you decide that you will use IRC on a regular basis, you may wish to
 register an IRC nickname that you may use each time you connect to IRC. Here
 are the basic steps to registering a nickname:
 
-* Pick a VERY INSECURE password (all communication with IRC is viewable by
+- Pick a VERY INSECURE password (all communication with IRC is viewable by
   anyone on the internet so don't use a sensitive password!!!) and use it to
   register, via email.
-* At the bottom of the messaging window, type the following (all IRC commands
+- At the bottom of the messaging window, type the following (all IRC commands
   begin with the forward slash):
 
-    `/msg nickserv register YOUR_INSECURE_PASSWORD your_email@address.com`
+  `/msg nickserv register YOUR_INSECURE_PASSWORD your_email@address.com`
 
-* Check your email and verify that you are now registered by following the
+- Check your email and verify that you are now registered by following the
   email's instructions (it'll tell you to type something like the following
   in the message window):
 
-    `/msg NickServ VERIFY REGISTER YOUR_NICKNAME THEIR_VERIFICATION_CODE`
-
-![registering your name](https://dl.dropboxusercontent.com/u/39730/freenode1.PNG)
-
+  `/msg NickServ VERIFY REGISTER YOUR_NICKNAME THEIR_VERIFICATION_CODE`
 
 ## Installing an IRC client
 
@@ -63,53 +57,52 @@ There are many different IRC clients available for Windows, Mac OSX, Linux, as
 well as Android and iOS.
 
 Some popular clients are:
-  * XChat (Linux, Mac OSX, Windows)
-  * LimeChat (Mac OSX)
-  * mIRC (Windows)
+
+- XChat (Linux, Mac OSX, Windows)
+- LimeChat (Mac OSX)
+- mIRC (Windows)
 
 ### Installing XChat
 
-* Download from http://xchat.org
-* Install and open. You will get the following window. Fill in Nickname with
+- Download from http://xchat.org
+- Install and open. You will get the following window. Fill in Nickname with
   the nickname you just registered. Fill in the * other fields if you'd like.
-* In "Networks", find and select "FreeNode"
+- In "Networks", find and select "FreeNode"
 
-![Networks](https://dl.dropboxusercontent.com/u/39730/freenode2.PNG)
+#### (Optional) XChat Configuration
 
-#### (Optional) Configure XChat so that you can Identify yourself to IRC and
-automatically join #pyladies whenever you open XChat.
+Configure XChat so that you can `Identify` yourself to IRC and automatically
+join `#pyladies` whenever you open XChat.
 
 Otherwise, you will have to do run these commands yourself to connect manually
 every time:
 
-`/msg nickserv identify YOUR_NICKNAME YOUR_INSECURE_PASSWORD`
-`/join #pyladies`
-
-
-![Auto](https://dl.dropboxusercontent.com/u/39730/freenode3.PNG)
-
+```
+/msg nickserv identify YOUR_NICKNAME YOUR_INSECURE_PASSWORD
+/join #pyladies
+```
 
 ## IRC Etiquette
 
-* Although IRC is an instant-messaging medium, people are not necessarily
+- Although IRC is an instant-messaging medium, people are not necessarily
   expected to respond immediately, even if they appear to be available in a
   chatroom.
-* To call someone out in particular, you can write (into the channel input line)
+- To call someone out in particular, you can write (into the channel input line)
   `ping PERSON'S_NICK`. When they are available, they will respond to you with
   the word "pong"
-* You are free to speak directly to specific people in the general channel
+- You are free to speak directly to specific people in the general channel
   (with the understanding that literally everyone will be listening in on your
   convo.
-* You may also privately message a person. It's good etiquette to first ask in
+- You may also privately message a person. It's good etiquette to first ask in
   the general channel if you may send them a private message. (Note: In XChat,
   right-click their nick and select "Open Dialogue Window")
-* Please be aware that IRC communication is transmitted in plaintext - i.e., it
+- Please be aware that IRC communication is transmitted in plaintext - i.e., it
   is very insecure (which is why you should register with a very casual
   password which you are not using for other accounts and NEVER share critical
   or privacy information over IRC)
 
-
 ## Well-known Python Channels on FreeNode
+
 * #pyladies
 * #python
 * #pycon
@@ -118,7 +111,6 @@ every time:
 * #pocoo
 * #positivepython
 * #openhatch
-
 
 ## Helpful commands
 

--- a/www/_posts/2013/2013-05-07-irc-resources.md
+++ b/www/_posts/2013/2013-05-07-irc-resources.md
@@ -5,45 +5,82 @@ tags: ["how-to", "irc"]
 category: [resources, pyladies]
 
 ---
+Updated August 24, 2015
+
+[IRC](http://en.wikipedia.org/wiki/Internet_Relay_Chat) is a great way to get
+in touch with open source developers around the world. The FreeNode network
+hosts chat rooms, formally called channels, for almost any open source project
+or framework which you are likely to encounter as a Python developer.
+
+PyLadies has it very own IRC channel #pyladies on the FreeNode network. Here's
+a guide for getting started with IRC and joining the discussion on the #pyladies
+channel. Let's start by using a web based IRC chat client, setting up an IRC
+nickname, and joining the friendly #pyladies channel.
 
 
-[IRC](http://en.wikipedia.org/wiki/Internet_Relay_Chat) is a great way to get in touch with open source developers around the world. The FreeNode network in particular is host to channels (chat rooms) for almost any open source framework you are likely to encounter as a Python developer.
+## Connect to IRC using a web client
 
-Here's a guide to setting up an IRC name and joining the #pyladies channel, a friendly place to become familiar with how IRC works.
+Let's start by using a web based IRC client:
 
-## Create your account
-
-* Go to http://webchat.freenode.net
-* For "Nickname", pick an available username (legal characters are anything <code>A-Z</code>, <code>0-9</code>, <code>-</code> and <code>_</code>)
-* Don't fill out anything else except the captcha, and hit "Connect"
+  * Go to https://webchat.freenode.net/?channels=pyladies
+  * For an IRC "Nickname", pick an available username (legal characters are
+    anything <code>A-Z</code>, <code>0-9</code>, <code>-</code> and <code>_</code>)
+  * Fill out the captcha code
+  * Do not fill in any other fields (other than nickname and captcha) and hit
+    the "Connect" button
 
 ![Webchat window](https://dl.dropboxusercontent.com/u/39730/freenode0.PNG)
 
 
-
 ## Register your Nickname
 
-* Pick a VERY INSECURE password (all communication with IRC is viewable by anyone on the internet so don't use a sensitive password!!!) and use it to register, via email.
-* At the bottom of the messaging window, type the following (all IRC commands begin with the forward slash):
+Once you decide that you will use IRC on a regular basis, you may wish to
+register an IRC nickname that you may use each time you connect to IRC. Here
+are the basic steps to registering a nickname:
 
-`/msg nickserv register YOUR_INSECURE_PASSWORD your_email@address.com`
+* Pick a VERY INSECURE password (all communication with IRC is viewable by
+  anyone on the internet so don't use a sensitive password!!!) and use it to
+  register, via email.
+* At the bottom of the messaging window, type the following (all IRC commands
+  begin with the forward slash):
 
-* Check your email and verify that you are now registered by following their instructions (it'll tell you to type something like the following in the message window:
+    `/msg nickserv register YOUR_INSECURE_PASSWORD your_email@address.com`
 
-`/msg NickServ VERIFY REGISTER YOUR_NICKNAME THEIR_VERIFICATION_CODE`
+* Check your email and verify that you are now registered by following the
+  email's instructions (it'll tell you to type something like the following
+  in the message window):
+
+    `/msg NickServ VERIFY REGISTER YOUR_NICKNAME THEIR_VERIFICATION_CODE`
 
 ![registering your name](https://dl.dropboxusercontent.com/u/39730/freenode1.PNG)
 
-## Install XChat
+
+## Installing an IRC client
+
+While a web client is a handy way to get started with IRC, you may wish to use
+an installed IRC client which is especially useful to follow multiple channels.
+There are many different IRC clients available for Windows, Mac OSX, Linux, as
+well as Android and iOS.
+
+Some popular clients are:
+  * XChat (Linux, Mac OSX, Windows)
+  * LimeChat (Mac OSX)
+  * mIRC (Windows)
+
+### Installing XChat
 
 * Download from http://xchat.org
-* Install and open. You will get the following window. Fill in Nickname with the nickname you just registered. Fill in the * other fields if you'd like.
+* Install and open. You will get the following window. Fill in Nickname with
+  the nickname you just registered. Fill in the * other fields if you'd like.
 * In "Networks", find and select "FreeNode"
 
 ![Networks](https://dl.dropboxusercontent.com/u/39730/freenode2.PNG)
 
-#### (Optional) Configure XChat so that you can Identify yourself to IRC and automatically join #pyladies whenever you open XChat.
-Otherwise, you have to do run these commands yourself every time:
+#### (Optional) Configure XChat so that you can Identify yourself to IRC and
+automatically join #pyladies whenever you open XChat.
+
+Otherwise, you will have to do run these commands yourself to connect manually
+every time:
 
 `/msg nickserv identify YOUR_NICKNAME YOUR_INSECURE_PASSWORD`
 `/join #pyladies`
@@ -51,13 +88,26 @@ Otherwise, you have to do run these commands yourself every time:
 
 ![Auto](https://dl.dropboxusercontent.com/u/39730/freenode3.PNG)
 
+
 ## IRC Etiquette
 
-* IRC is an instant-messaging medium but people are not necessarily expected to respond immediately, even if they appear to be available in a chatroom .
-* To call someone out in particular, you can write (into the channel) `ping PERSON'S_NICK`
-* When they are available, they will respond to you with "pong"
-* You are free to speak directly to specific people in the general channel (with the understanding that literally everyone will be listening in on your convo, but you can also privately message them (in XChat, right-click their nick and select "Open Dialogue Window"
-* Please be aware that IRC communication is transmitted in plaintext - i.e., it is very insecure (which is why you should register with a very casual password and NEVER share critical information over IRC)
+* Although IRC is an instant-messaging medium, people are not necessarily
+  expected to respond immediately, even if they appear to be available in a
+  chatroom.
+* To call someone out in particular, you can write (into the channel input line)
+  `ping PERSON'S_NICK`. When they are available, they will respond to you with
+  the word "pong"
+* You are free to speak directly to specific people in the general channel
+  (with the understanding that literally everyone will be listening in on your
+  convo.
+* You may also privately message a person. It's good etiquette to first ask in
+  the general channel if you may send them a private message. (Note: In XChat,
+  right-click their nick and select "Open Dialogue Window")
+* Please be aware that IRC communication is transmitted in plaintext - i.e., it
+  is very insecure (which is why you should register with a very casual
+  password which you are not using for other accounts and NEVER share critical
+  or privacy information over IRC)
+
 
 ## Well-known Python Channels on FreeNode
 * #pyladies
@@ -67,7 +117,8 @@ Otherwise, you have to do run these commands yourself every time:
 * #pyramid
 * #pocoo
 * #positivepython
-* #openhatch 
+* #openhatch
+
 
 ## Helpful commands
 


### PR DESCRIPTION
Closes #154 by updating the content in the How to IRC resource from 2013. Adds clarifying wording, suggested clients, and web client links directly to #pyladies channel for login.
