### PR TITLE
Fix font inconsistency among heading tags

### DIFF
--- a/www/_assets/css/screen.css
+++ b/www/_assets/css/screen.css
@@ -245,7 +245,7 @@ h3.chpts {
 }
 
 h4, h5, h6 {
-  font-family: "Arial", "Helvetica", sans-serif;
+  font-family: 'Glegoo', serif;
   font-style: normal;
   text-transform: uppercase;
 }


### PR DESCRIPTION
Fixing https://github.com/pyladies/pyladies/issues/147 -

Currently the `h4`, `h5`, and `h6` tags use a different font from the higher level headings (sans-serif vs serif). I updated the font for the lower heading tags so they match the other headings.

Before:

![screen shot 2015-10-16 at 6 53 01 pm](https://cloud.githubusercontent.com/assets/1066522/10555218/bc44b9ba-7439-11e5-832e-44b189cc23a2.png)

After:

![screen shot 2015-10-16 at 6 54 42 pm](https://cloud.githubusercontent.com/assets/1066522/10555222/c5788d86-7439-11e5-89f5-9822509f8acd.png)

