### PR TITLE
updated circle.yml to install mynt 0.3.1

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -12,7 +12,7 @@ machine:
 ## Customize dependencies
 dependencies:
   pre:
-    - pip install mynt==0.2.3 Fabric==1.10.2
+    - pip install mynt==0.3.1 Fabric==1.10.2
 
 ## Customize database setup
 


### PR DESCRIPTION
 Many of the sub-domains list the older version of mynt in their respective requirements.txt files; should those be updated as well? 