### PR TITLE
Redirect blog link to new location

### DIFF
--- a/www/_templates/site.html
+++ b/www/_templates/site.html
@@ -43,7 +43,7 @@
                 <li><a href="{{ get_url('about/') }}">About</a></li>
                 <li><a href="http://discuss.pyladies.com">Forum</a></li>
                 <li><a href="{{ get_url('locations/') }}">Locations</a></li>
-                <li><a href="{{ get_url('blog/') }}">Blog</a></li>
+                <li><a href="http://blog.pyladies.com">Blog</a></li>
                 <li><a href="{{ get_url('CodeOfConduct/') }}">Code of Conduct</a></li>
                 <li><a href="{{ get_url('resources/') }}">Resources</a></li>
                 <li><a href="mailto:info@pyladies.com?subject=Hello" id="contact-link">Contact</a></li>


### PR DESCRIPTION
Since we've separated out the blog into it's own repo and hosted now on Heroku ([here](http://pyladies-blog.herokuapp.com/)), we now need to redirect the header link to it (once DNS propagates).

Still todo (in this order):
* Redirect pyladies.com/blog/$1 to blog.pyladies.com/$1
* Remove the posts from this repo to avoid confusion
* Update docs of this repo of where to find the blog repo

(will merge & deploy once DNS updates)