### PR TITLE
Upgrading version of Fabric

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 mynt==0.3.1
-Fabric==1.10.2
+Fabric==1.13.1
 docutils


### PR DESCRIPTION
Looks like there's an underlying issue specific to Fabric 1.10.2, so upgrading Fabric in hopes that the fab deploy step will no longer break on `ImportError: No module named Crypto`