### PR TITLE
Fixing rsync command in fabfile

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -19,7 +19,7 @@ def prep_www_deploy():
 
 def rsync_www():
     with lcd("www"):
-        rsync_project(local_dir="_site",
+        rsync_project(local_dir="_site/",
                       remote_dir="www/",
                       extra_opts="-ua")
 


### PR DESCRIPTION
From what I can tell, files are being copied into a subfolder in www, when we want the contents to be copied over. I think we may need, after deployment, to manually delete the _site folder where files are currently being copied over. 