### PR TITLE
Add target for external link to dublin

### DIFF
--- a/www/locations/dublin/index.html
+++ b/www/locations/dublin/index.html
@@ -6,7 +6,7 @@
             <article>
                 <ul class="social">
                     <aside>
-                        <h4><a href="{{ get_url("locations/dublin") }}">Dublin, Ireland</a> | <a class="social icon vcard" data-icon="&#59170;" href="mailto:dublin@pyladies.com" title"Contact"></a><a class="social icon location" data-icon="&#59172;" title="Meetup Link" href="http://www.meetup.com/PyLadiesDublin/"></a></h4>
+                        <h4><a href="{{ get_url("locations/dublin") }}">Dublin, Ireland</a> | <a class="social icon vcard" data-icon="&#59170;" href="mailto:dublin@pyladies.com" title"Contact"></a><a class="social icon location" data-icon="&#59172;" title="Meetup Link" href="http://www.meetup.com/PyLadiesDublin/" target="_blank"></a></h4>
 
                 </aside>
                 </ul>


### PR DESCRIPTION
From mailing list, dublin link is not directing to their meetup page. 503 error on Heroku. This PR adds a blank target to the html link statement.

@estherbester Would you mind reviewing? Thanks.
