### PR TITLE
Get Tirana listed under locations

### DIFF
--- a/www/config.yml
+++ b/www/config.yml
@@ -778,6 +778,15 @@ chapters:
             latitude: -5.1816948
             longitude: -43.0212865
 
+      - name:      Tirana, Albania
+        email: tirana@pyladies.com
+        facebook: PyLadiesTirana
+        github: PyLadiesTirana
+        twitter: PyLadiesTirana
+        location:
+              latitude: 41.327953
+              longitude: 19.819025
+
     - name:      Tokyo
       website: http://tokyo.pyladies.com/
       external_website: true


### PR DESCRIPTION
I edited config.yml file to get Tirana listed under [locations](http://www.pyladies.com/locations/) . I added email, location and some accounts usernames. I will update it soon once we build our static website. 