### PR TITLE
Add timepad to main page widget

### DIFF
--- a/www/_templates/site.html
+++ b/www/_templates/site.html
@@ -24,7 +24,11 @@
                                  {{ chapter.meetup_id }}
                                  {%- if not loop.last -%},{% endif %}
                             {%- endfor -%}";
-            PyladiesMeetupWidget.addUpcomingMeetups(meetupIds);
+             var timepadPages = "{% for chapter in site.chapters if chapter.timepad_id -%}
+                                 {{ chapter.timepad_id }}
+                                 {%- if not loop.last -%},{% endif %}
+                            {%- endfor -%}";
+            PyladiesMeetupWidget.addUpcomingMeetups(meetupIds, timepadPages);
         });
 	</script>
 	{% endblock %}

--- a/www/config.yml
+++ b/www/config.yml
@@ -699,6 +699,7 @@ chapters:
       email: spb@pyladies.com
       twitter: pyladies_spb
       timepad: pyladies-spb
+      timepad_id: 135287
       location:
             latitude: 59.9343
             longitude: 30.3351


### PR DESCRIPTION
Motivation: There are already PyLadies Moscow and PyLadies Kazan, and they will be using timepad.ru
because it is analog of meetup.com which is free of charge and has better local support.

So I, as coorg of PyLadies SPb, added events from timepad.ru to the main page, to boost the visibility of local Russian chapters.

Also I added the timepad_id for PyLadies SPb chapter to config file.


