### PR TITLE
added missing equal sign for some html title attributes

### DIFF
--- a/www/locations/index.html
+++ b/www/locations/index.html
@@ -45,10 +45,10 @@
                             <a class="social icon vcard" data-icon="&#59170;" href="mailto:{{chapter.email}}" title="Contact"></a>
                             {% endif %}
                             {% if chapter.facebook %}
-                            <a class="social icon facebook" data-icon="&#62221;" href="https://www.facebook.com/{{chapter.facebook}}" title"Facebook"></a>
+                            <a class="social icon facebook" data-icon="&#62221;" href="https://www.facebook.com/{{chapter.facebook}}" title="Facebook"></a>
                             {% endif %}
                             {% if chapter.github %}
-                            <a class="social icon github" data-icon="&#62208;" href="https://github.com/{{chapter.github}}" title"GitHub"></a>
+                            <a class="social icon github" data-icon="&#62208;" href="https://github.com/{{chapter.github}}" title="GitHub"></a>
                             {% endif %}
                             {% if chapter.twitter %}
                             <a class="social icon twitter" data-icon="&#62217;" href="https://twitter.com/{{chapter.twitter}}" title="Twitter"></a>
@@ -57,7 +57,7 @@
                             <a class="social icon location" data-icon="&#59172;" title="Meetup Link" href="http://www.meetup.com/{{chapter.meetup}}/"></a>
                             {% endif %}
                             {% if chapter.google_plus %}
-                            <a class="social icon google-plus" data-icon="&#62223;" href="{{chapter.google_plus}}" title"Google+"></a>
+                            <a class="social icon google-plus" data-icon="&#62223;" href="{{chapter.google_plus}}" title="Google+"></a>
                             {% endif %}
                             {% if chapter.timepad%}
                             <a class="social icon location" data-icon="&#59172;" title="Timepad Link" href="https://{{chapter.timepad}}.timepad.ru"></a>


### PR DESCRIPTION
For the social median icon links on the location page, the title attribute for Facebook, Github, and Google+ were missing an equal sign. 