### PR TITLE
Add deploy to production to circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,3 +42,25 @@ jobs:
           paths:
             - venv
           key: v2-dependencies-{{ checksum "requirements.txt" }}
+
+  deploy-prod:
+    docker:
+      - image: circleci/python:2.7.16-node-browsers
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - run:
+          name: deploy master
+          command: |
+            fab prep_www_deploy
+            fab rsync_www
+
+workflows:
+  version: 2
+  build-deploy:
+    jobs:
+      - build
+      - deploy-prod:
+          filters:
+            branches:
+              only: master


### PR DESCRIPTION
Closes #350 

- Uses Fabric instead of migrating to Fabric2
- @estherbester @econchick I don't have admin privileges so I can't set CircleCI to try a deploy