### PR TITLE
Add height and width to twitter timeline box

### DIFF
--- a/www/_templates/site.html
+++ b/www/_templates/site.html
@@ -83,7 +83,7 @@
         <div id="twitter_feed">
             <h3>Recent Tweets</h3>
             <div id="chapter_tweets">
-                <a class="twitter-timeline" href="https://twitter.com/pyladies/lists/pyladies-locations" data-widget-id="635861904234258433">Tweets from https://twitter.com/pyladies/lists/pyladies-locations</a>
+                <a width="400" height="400" class="twitter-timeline" href="https://twitter.com/pyladies/lists/pyladies-locations" data-widget-id="635861904234258433">Tweets from https://twitter.com/pyladies/lists/pyladies-locations</a>
                 <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
             </div>
 		</div>


### PR DESCRIPTION
Corrects the twitter content from running off the bottom of the page.

<img width="1194" alt="Screenshot 2019-03-08 18 02 08" src="https://user-images.githubusercontent.com/2680980/54064763-9b879a80-41cc-11e9-9aaa-1f4d16f8aed6.png">
