### PR TITLE
Require build for deploy and add pip install reqs to deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,9 +46,15 @@ jobs:
   deploy-prod:
     docker:
       - image: circleci/python:2.7.16-node-browsers
-    working_directory: ~/repo
+    working_directory: ~/pyladies
     steps:
       - checkout
+      - run:
+          name: install dependencies and version
+          command: |
+            . venv/bin/activate
+            pip install --upgrade pip setuptools wheel
+            pip install -r requirements.txt
       - run:
           name: deploy master
           command: |
@@ -61,6 +67,8 @@ workflows:
     jobs:
       - build
       - deploy-prod:
+          requires:
+            - build
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,18 +24,12 @@ jobs:
       - run:
           name: install dependencies and version
           command: |
-            python2 -m pip install --upgrade pip setuptools wheel
-            python2 -m pip install virtualenv
-            virtualenv venv
-            . venv/bin/activate
-            cd ..
-            pip install --upgrade pip setuptools wheel
-            pip install -r ~/pyladies/requirements.txt
+            pip install --user --upgrade pip setuptools wheel
+            pip install --user -r requirements.txt
 
       - run:
           name: python tests
           command: |
-            . venv/bin/activate
             ./test_www.py > mytest.log
             cat mytest.log
       - save_cache:
@@ -52,9 +46,8 @@ jobs:
       - run:
           name: install dependencies and version
           command: |
-            . venv/bin/activate
-            pip install --upgrade pip setuptools wheel
-            pip install -r requirements.txt
+            pip install --user --upgrade pip setuptools wheel
+            pip install --user -r requirements.txt
       - run:
           name: deploy master
           command: |


### PR DESCRIPTION
Getting this error when CircleCI runs for `deploy`:

```
#!/bin/bash -eo pipefail
fab prep_www_deploy
fab rsync_www
/bin/bash: fab: command not found
Exited with code 127
```

so I'm seeing if adding `requires: build`, getting rid of virtualenvs and installing into user space (not ideal but virtualenvs weren't working, it seems), and installing dependencies for deploy.