### PR TITLE
Fixed #390: Added link to Slack chat to about page

### DIFF
--- a/www/about/index.html
+++ b/www/about/index.html
@@ -17,6 +17,7 @@
                 <li>Join our global <a href="https://plus.google.com/communities/108807002736066163985">Google+ community</a> to keep up with recent Pyladies conversations.</li>
                 <li>Come to our IRC channel #pyladies on irc.freenode.net.  Say hi and tell us a bit about yourself.  We'll do the same :)  Hang out and make yourself at home.  Don't be shy; we'd love to meet you.</li>
                 <li>Sign up for our <a href="https://groups.google.com/forum/#!forum/pyladies">Google Group discussion list</a>.</li>
+                <li>Join the PyLadies <a href="https://slackin.pyladies.com">Slack chat</a>.</li>
                 <li><a href="mailto:info@pyladies.com">E-mail us</a></li>
             </ol>
             <p></p>


### PR DESCRIPTION
Fixed issue #390 (Add "how to to join slack" on About page)
I updated the index.html file of the about page with a link to the PyLadies slack chat! 