### PR TITLE
Replacing the info email for the info GitHub repo

### DIFF
--- a/www/_posts/2014/2014-04-26-Attend-Google-IO-with-PyLadies.md
+++ b/www/_posts/2014/2014-04-26-Attend-Google-IO-with-PyLadies.md
@@ -39,6 +39,6 @@ Timeline:
 * Award recipients must register within 2 weeks of receiving award letter and signup process
 
 
-All information here will not be made public, and will be reviewed by PyLadies leadership only.  Please email [info@pyladies.com](mailto:info@pyladies.com) regarding any questions you have.
+All information here will not be made public, and will be reviewed by PyLadies leadership only.  Please [open a issue](https://github.com/pyladies/info/issues/new) regarding any questions you have.
 
 [**APPLY HERE**](https://docs.google.com/forms/d/1lK9gOqSZKpFu9ZZ_DSDHzYiOQRAgqUYGnBIqcD2vJL0/viewform)

--- a/www/_posts/2014/2014-04-26-Attend-Google-IO-with-PyLadies.md
+++ b/www/_posts/2014/2014-04-26-Attend-Google-IO-with-PyLadies.md
@@ -39,6 +39,6 @@ Timeline:
 * Award recipients must register within 2 weeks of receiving award letter and signup process
 
 
-All information here will not be made public, and will be reviewed by PyLadies leadership only.  Please [open a issue](https://github.com/pyladies/info/issues/new) regarding any questions you have.
+All information here will not be made public, and will be reviewed by PyLadies leadership only.  Please [open an issue](https://github.com/pyladies/info/issues/new) regarding any questions you have.
 
 [**APPLY HERE**](https://docs.google.com/forms/d/1lK9gOqSZKpFu9ZZ_DSDHzYiOQRAgqUYGnBIqcD2vJL0/viewform)

--- a/www/_posts/2014/2014-04-26-Attend-Google-IO-with-PyLadies.md
+++ b/www/_posts/2014/2014-04-26-Attend-Google-IO-with-PyLadies.md
@@ -39,6 +39,6 @@ Timeline:
 * Award recipients must register within 2 weeks of receiving award letter and signup process
 
 
-All information here will not be made public, and will be reviewed by PyLadies leadership only.  Please [open an issue](https://github.com/pyladies/info/issues/new) regarding any questions you have.
+All information here will not be made public, and will be reviewed by PyLadies leadership only.  Please [contact us](https://github.com/pyladies/info/issues/new) regarding any questions you have.
 
 [**APPLY HERE**](https://docs.google.com/forms/d/1lK9gOqSZKpFu9ZZ_DSDHzYiOQRAgqUYGnBIqcD2vJL0/viewform)

--- a/www/_posts/2014/2014-08-25-community-conduct-and-compassion-resources.md
+++ b/www/_posts/2014/2014-08-25-community-conduct-and-compassion-resources.md
@@ -5,7 +5,7 @@ tags: [community, education]
 category: [pyladies, resources]
 ---
 
-There are a number of excellent resources on creating healthy, inclusive steps for communities. These are just a few of them. If you think another PyLady would find a resource useful that is not on this list, please [submit a pull request](https://github.com/pyladies/pyladies) or [email the link to us](mailto:info@pyladies.com). Thank you!
+There are a number of excellent resources on creating healthy, inclusive steps for communities. These are just a few of them. If you think another PyLady would find a resource useful that is not on this list, please [submit a pull request](https://github.com/pyladies/pyladies) or [open an issue with the link](https://github.com/pyladies/info/issues/new). Thank you!
 
 [The PSF] (https://www.python.org/community/diversity/)
 

--- a/www/_templates/site.html
+++ b/www/_templates/site.html
@@ -51,7 +51,7 @@
                 <li><a href="https://blog.pyladies.com">Blog</a></li>
                 <li><a href="{{ get_url('CodeOfConduct/') }}">Code of Conduct</a></li>
                 <li><a href="{{ get_url('resources/') }}">Resources</a></li>
-                <li><a href="https://github.com/pyladies/info/issues/new" id="contact-link">Contact</a></li>
+                <li><a href="https://github.com/pyladies/info/" id="contact-link">Contact</a></li>
                 {% if site.feed %}<li><a href="{{ get_url('feed.xml', true)}}" title="RSS">RSS</a></li>{% endif %}
             </ul>
         </nav>

--- a/www/_templates/site.html
+++ b/www/_templates/site.html
@@ -51,7 +51,7 @@
                 <li><a href="https://blog.pyladies.com">Blog</a></li>
                 <li><a href="{{ get_url('CodeOfConduct/') }}">Code of Conduct</a></li>
                 <li><a href="{{ get_url('resources/') }}">Resources</a></li>
-                <li><a href="mailto:info@pyladies.com?subject=Hello" id="contact-link">Contact</a></li>
+                <li><a href="https://github.com/pyladies/info/issues/new" id="contact-link">Contact</a></li>
                 {% if site.feed %}<li><a href="{{ get_url('feed.xml', true)}}" title="RSS">RSS</a></li>{% endif %}
             </ul>
         </nav>

--- a/www/about/index.html
+++ b/www/about/index.html
@@ -14,7 +14,7 @@
             <ol>
                 <li>Join your local <a href="{{ get_url('/locations') }}">Meetup group</a> or start your own with our <a href="http://github.com/pyladies/pyladies-kit">PyLadies starter kit</a></li>
                 <li>Join the PyLadies <a href="https://slackin.pyladies.com">Slack chat</a>.</li>
-                <li><a href="https://github.com/pyladies/info/issues/new">Open an issue</a></li>
+                <li><a href="https://github.com/pyladies/info/issues/new">Ask questions!</a></li>
             </ol>
             <p></p>
             <p>**Developers and aspiring developers only, please!  There are some fantastic groups for women in other areas of technology, which some of us participate in as well, but let's keep this group primarily focused on Python programming.</p>

--- a/www/about/index.html
+++ b/www/about/index.html
@@ -14,7 +14,7 @@
             <ol>
                 <li>Join your local <a href="{{ get_url('/locations') }}">Meetup group</a> or start your own with our <a href="http://github.com/pyladies/pyladies-kit">PyLadies starter kit</a></li>
                 <li>Join the PyLadies <a href="https://slackin.pyladies.com">Slack chat</a>.</li>
-                <li><a href="mailto:info@pyladies.com">E-mail us</a></li>
+                <li><a href="https://github.com/pyladies/info/issues/new">Open an issue</a></li>
             </ol>
             <p></p>
             <p>**Developers and aspiring developers only, please!  There are some fantastic groups for women in other areas of technology, which some of us participate in as well, but let's keep this group primarily focused on Python programming.</p>

--- a/www/locations/nash/index.html
+++ b/www/locations/nash/index.html
@@ -6,7 +6,7 @@
             <article>
                 <ul class="social">
                     <aside>
-                        <h4><a href="{{ get_url("locations/nash") }}">Nashville, TN</a> | <a class="social icon vcard" data-icon="&#59170;" href="mailto:info@pyladies.com" title"Contact"></a><a class="social icon twitter" data-icon="&#62217;" title="Twitter" href="https://twitter.com/PyNashLadies"></a><a class="social icon location" data-icon="&#59172;" title="Meetup Link" href="http://www.meetup.com/Nashville-PyLadies"></a></h4>
+                        <h4><a href="{{ get_url("locations/nash") }}">Nashville, TN</a> | <a class="social icon vcard" data-icon="&#59170;" href="https://github.com/pyladies/info/issues/new" title"Contact"></a><a class="social icon twitter" data-icon="&#62217;" title="Twitter" href="https://twitter.com/PyNashLadies"></a><a class="social icon location" data-icon="&#59172;" title="Meetup Link" href="http://www.meetup.com/Nashville-PyLadies"></a></h4>
                     </aside>
                 </ul>
             </article>

--- a/www/sponsor/index.html
+++ b/www/sponsor/index.html
@@ -15,7 +15,7 @@
                 <li>Make a donation through the <a href="https://psfmember.org/civicrm/contribute/transact?reset=1&id=6">Python Software Foundation</a>.  Donations made are tax-deductible. If you would prefer not to use credit card or PayPal, please contact <a href="mailto:sponsors@pyladies.com">us</a> to make other arrangements.</li>
             </ol>
 
-            <p>If you know of a talented, deserving developer who might benefit greatly from attending a Python or Open Source conference, <a href="https://github.com/pyladies/info/issues/new">open a issue</a>.  We'll do our best to help as many women as possible.</p>
+            <p>If you know of a talented, deserving developer who might benefit greatly from attending a Python or Open Source conference, <a href="https://github.com/pyladies/info/issues/new">open an issue</a>.  We'll do our best to help as many women as possible.</p>
         </article>
     </section>
 {% endblock %}

--- a/www/sponsor/index.html
+++ b/www/sponsor/index.html
@@ -15,7 +15,7 @@
                 <li>Make a donation through the <a href="https://psfmember.org/civicrm/contribute/transact?reset=1&id=6">Python Software Foundation</a>.  Donations made are tax-deductible. If you would prefer not to use credit card or PayPal, please contact <a href="mailto:sponsors@pyladies.com">us</a> to make other arrangements.</li>
             </ol>
 
-            <p>If you know of a talented, deserving developer who might benefit greatly from attending a Python or Open Source conference, email <a href="mailto:info@pyladies.com">us</a>.  We'll do our best to help as many women as possible.</p>
+            <p>If you know of a talented, deserving developer who might benefit greatly from attending a Python or Open Source conference, <a href="https://github.com/pyladies/info/issues/new">open a issue</a>.  We'll do our best to help as many women as possible.</p>
         </article>
     </section>
 {% endblock %}

--- a/www/sponsor/index.html
+++ b/www/sponsor/index.html
@@ -15,7 +15,7 @@
                 <li>Make a donation through the <a href="https://psfmember.org/civicrm/contribute/transact?reset=1&id=6">Python Software Foundation</a>.  Donations made are tax-deductible. If you would prefer not to use credit card or PayPal, please contact <a href="mailto:sponsors@pyladies.com">us</a> to make other arrangements.</li>
             </ol>
 
-            <p>If you know of a talented, deserving developer who might benefit greatly from attending a Python or Open Source conference, <a href="https://github.com/pyladies/info/issues/new">open an issue</a>.  We'll do our best to help as many women as possible.</p>
+            <p>If you know of a talented, deserving developer who might benefit greatly from attending a Python or Open Source conference, <a href="https://github.com/pyladies/info/issues/new">let us know</a>.  We'll do our best to help as many women as possible.</p>
         </article>
     </section>
 {% endblock %}


### PR DESCRIPTION
This is related to #428 

As discussed in the Feb 12th meeting this changes all the info email references to the pyladies/info repo.