### PR TITLE
bump stockholm dependencies for python 3.8 build

### DIFF
--- a/sthlm/requirements.txt
+++ b/sthlm/requirements.txt
@@ -1,1 +1,11 @@
-mynt==0.2.3
+cffi==1.15.1
+hoep==1.0.2
+houdini.py==0.1.0
+Jinja2==3.1.2
+MarkupSafe==2.1.3
+misaka==2.1.1
+mynt==0.4
+pycparser==2.21
+Pygments==2.15.1
+PyYAML==6.0
+watchdog==3.0.0


### PR DESCRIPTION
This PR bumps the dependencies in Stockholm directory so:
- Python 3.8 build works without error