### PR TITLE
Update requirements.txt to remove hoep

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ cffi==1.15.1
 cryptography==41.0.3
 docutils==0.14
 enum34==1.1.6
-hoep==1.0.2
+# hoep==1.0.2  remove to test CI
 idna==2.6
 ipaddress==1.0.18
 Jinja2==2.9.6


### PR DESCRIPTION
CI is failing on #671. It's getting an error due to `hoep` dependency not building.