### PR TITLE
Use PSF's CoC

### DIFF
--- a/www/_posts/2013/2013-04-10-Code-of-Conduct.md
+++ b/www/_posts/2013/2013-04-10-Code-of-Conduct.md
@@ -5,12 +5,9 @@ tags: [CoC]
 category: [codeconduct]
 ---
 
-<p>Pyladies is dedicated to providing a respectful, harassment-free community for everyone. We do not tolerate harassment or bullying of any community member in any form. This does not only extend to members to local PyLadies communities, but to anyone who chooses to become involved in the larger PyLadies community of users, developers and integrators through events or interactions.</p>
+As a fiscal sponsoree of the Python Software Foundation, we adhere to their [Code of Conduct][PSF COC].
+Refer to the [Code of Conduct page] in the [PyLadies kit] for the full policy and contact information.
 
-<p>Harassment includes offensive verbal/electronic comments related to personal characteristics or choices, sexual images or comments in public or online spaces, deliberate intimidation, bullying, stalking, following, harassing photography or recording, sustained disruption of talks, IRC chats, electronic meetings, physical meetings or other events, inappropriate physical contact, or unwelcome sexual attention. Participants asked to stop any harassing or bullying behavior are expected to comply immediately.</p>
-
-<p>If a participant engages in harassing behavior, representatives of the community may take reasonable action they deem appropriate, including warning the offender, expulsion from any PyLadies event, or expulsion from mailing lists, IRC chats, discussion boards and other electronic communications channels to resolve the issue. This may include expulsion from PyLadies Meetup group membership.</p>
-
-<p>If you are being harassed, notice that someone else is being harassed, or have any other concerns, please act to intercede or ask for help from any member of the PyLadies community, IRC chat admins, website admins, or organizers/representatives of any physical events put on under the auspices of PyLadies.</p>
-
-<p>This Code of Conduct has been adapted from the <a href="http://plone.org/foundation/materials/foundation-resolutions/code-of-conduct">Plone Foundation</a> and is licensed under a <a href="http://creativecommons.org/licenses/by-sa/3.0/">Creative Commons Attribution-Share Alike 3.0 Unported license</a></p>
+[PSF COC]: https://policies.python.org/python.org/code-of-conduct/
+[Code of Conduct page]: https://kit.pyladies.com/en/latest/policies/coc.html
+[PyLadies kit]: https://kit.pyladies.com


### PR DESCRIPTION
As a fiscal sponsoree of the PSF, we are required to use & adhere to their Code of Conduct - finally updating the site to reflect that! (depends on this [kit PR](https://github.com/pyladies/pyladies-kit/pull/124) getting merged in first)